### PR TITLE
Fix #2: Deprecation: opIn_r is deprecated.

### DIFF
--- a/src/hyphenate.d
+++ b/src/hyphenate.d
@@ -125,7 +125,7 @@ struct Trie
 
     static struct Table
     {
-        inout(Trie)* opIn_r(dchar c) inout
+        inout(Trie)* opBinaryRight(string op : "in")(dchar c) inout
         {
             if (c >= 128 || !bt(bitmask.ptr, c))
                 return null;


### PR DESCRIPTION
`opIn_r` is due to be removed in https://github.com/dlang/dmd/pull/12902.