### PR TITLE
Resolve deprecation of `body` keyword.

### DIFF
--- a/src/hyphenate.d
+++ b/src/hyphenate.d
@@ -30,8 +30,7 @@ struct BitArray
 
     ///
     @property ubyte front() const
-    in { assert(!empty); }
-    body
+    in (!empty)
     {
         return cast(ubyte)((!!(_bits & 1) ? bsf(~_bits) : bsf(_bits)) - 1);
     }
@@ -45,8 +44,7 @@ struct BitArray
 
 private:
     uint encode(R)(in R data)
-    in { assert(reduce!"a+b"(0, data) + data.length < 32, data.to!string()); }
-    body
+    in (reduce!"a+b"(0, data) + data.length < 32, data.to!string())
     {
         uint res = fillBits;
         size_t i;


### PR DESCRIPTION
Please tag a new release and upgrade ddox, as it causes similar effects as dlang/dub#2241. The new ddox version will be referenced in dlang/dub#2254.